### PR TITLE
close stdin so that stdout receives input

### DIFF
--- a/lib/png_quantizator.rb
+++ b/lib/png_quantizator.rb
@@ -30,6 +30,7 @@ module PngQuantizator
 
       exit_code, err_msg = Open3.popen3("pngquant #{colors}") do |stdin, stdout, stderr, wait_thr|
         stdin.write(File.read(@file_path))
+        stdin.close
 
         File.open(destination_path, "w") do |f|
           f.write stdout.gets(nil)


### PR DESCRIPTION
For me quantize_to would never return, being stuck in stdout.gets(nil). Sending EOF to stdin solves this issue.
